### PR TITLE
Fix bold fonts on MacOS/Webkit browsers

### DIFF
--- a/static/stylesheet.css
+++ b/static/stylesheet.css
@@ -1,5 +1,8 @@
 body {
     height: 100%;
+
+    /* https://stackoverflow.com/questions/37793086/ */
+    -webkit-font-smoothing: antialiased;
 }
 
 .mainblock {


### PR DESCRIPTION
Ref: https://stackoverflow.com/questions/37793086/why-is-the-font-style-bold-not-correctly-applied-in-chrome-on-this-website